### PR TITLE
feat: add interactive board UI (#4)

### DIFF
--- a/src/chess/chessState.ts
+++ b/src/chess/chessState.ts
@@ -36,6 +36,11 @@ export type MoveRecord = LegalMove & {
   after: string;
 };
 
+export type BoardPiece = {
+  type: PieceSymbol;
+  color: Color;
+};
+
 export type MoveResult =
   | {
       ok: true;
@@ -66,6 +71,10 @@ export class ChessState {
 
   getSideToMove(): Color {
     return this.chess.turn();
+  }
+
+  getPiece(square: Square): BoardPiece | null {
+    return this.chess.get(square);
   }
 
   isInCheck(): boolean {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/ui/app-shell/AppShell.module.css
+++ b/src/ui/app-shell/AppShell.module.css
@@ -112,17 +112,6 @@
   gap: var(--space-lg);
 }
 
-.boardPlaceholder {
-  aspect-ratio: 1 / 1;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--color-border);
-  background: var(--color-panel);
-  display: grid;
-  place-items: center;
-  color: var(--color-ink-muted);
-  font-size: var(--font-size-base);
-}
-
 .mainMeta {
   padding: var(--space-md);
   border-radius: var(--radius-md);

--- a/src/ui/app-shell/AppShell.tsx
+++ b/src/ui/app-shell/AppShell.tsx
@@ -1,3 +1,4 @@
+import { Board } from "../board/Board";
 import styles from "./AppShell.module.css";
 
 const APP_TITLE = "Chess App";
@@ -17,7 +18,7 @@ export function AppShell() {
 
       <main className={styles.main}>
         <section className={styles.boardCard} aria-label="Board area">
-          <div className={styles.boardPlaceholder}>Board placeholder</div>
+          <Board />
           <div className={styles.mainMeta}>
             Move list, clocks, and controls will live in this space.
           </div>

--- a/src/ui/board/Board.integration.test.tsx
+++ b/src/ui/board/Board.integration.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Board } from "./Board";
+
+const START_FEN =
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const EXPECTED_KNIGHT_DESTINATIONS = ["a3", "c3"];
+const EXPECTED_FEN_AFTER_E4 =
+  "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+const EXPECTED_SIDE_AFTER_E4 = "Black";
+
+const getLegalDestinations = (board: HTMLElement): string[] =>
+  Array.from(
+    board.querySelectorAll('[data-legal-destination="true"]')
+  )
+    .map((element) => element.getAttribute("data-square"))
+    .filter((square): square is string => Boolean(square));
+
+const sortSquares = (squares: string[]): string[] => [...squares].sort();
+
+describe("Board integration", () => {
+  it("shows the legal destinations for a selected piece", () => {
+    render(<Board initialFen={START_FEN} />);
+
+    const board = screen.getByRole("grid", { name: /chess board/i });
+    const knightSquare = screen.getByTestId("square-b1");
+
+    fireEvent.click(knightSquare);
+
+    const destinations = getLegalDestinations(board);
+
+    expect(destinations).toHaveLength(EXPECTED_KNIGHT_DESTINATIONS.length);
+    expect(sortSquares(destinations)).toEqual(
+      sortSquares(EXPECTED_KNIGHT_DESTINATIONS)
+    );
+  });
+
+  it("updates FEN and side to move after a move", () => {
+    render(<Board initialFen={START_FEN} />);
+
+    fireEvent.click(screen.getByTestId("square-e2"));
+    fireEvent.click(screen.getByTestId("square-e4"));
+
+    expect(screen.getByTestId("fen-value").textContent).toBe(
+      EXPECTED_FEN_AFTER_E4
+    );
+    expect(screen.getByTestId("side-to-move").textContent).toBe(
+      EXPECTED_SIDE_AFTER_E4
+    );
+  });
+});

--- a/src/ui/board/Board.module.css
+++ b/src/ui/board/Board.module.css
@@ -1,0 +1,180 @@
+:global(:root) {
+  /* Board-specific constants for predictable layout and contrast. */
+  --board-grid-size: 8;
+  --board-max-size: 32rem;
+  --board-border-width: 1px;
+  --board-light-square: #f2d6b3;
+  --board-dark-square: #b67b4d;
+  --board-piece-size: clamp(1.4rem, 2.8vw, 2.6rem);
+  --board-piece-weight: 600;
+  --board-piece-white: #fdf9f4;
+  --board-piece-black: #2b1f16;
+  --board-selection-ring: 3px;
+  --board-selection-color: var(--color-accent);
+  --board-last-move-ring: 3px;
+  --board-last-move-color: rgba(160, 91, 46, 0.35);
+  --board-legal-indicator-size: 42%;
+  --board-legal-indicator-border: 3px;
+  --board-legal-indicator-color: rgba(31, 26, 23, 0.35);
+  --board-focus-ring: 3px;
+  --board-focus-color: rgba(31, 26, 23, 0.5);
+  --board-error-border: #d5a6a6;
+  --board-error-background: #f6e8e8;
+  --board-error-text: #5b1d1d;
+}
+
+.panel {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.boardWrapper {
+  display: grid;
+  justify-items: center;
+}
+
+.board {
+  width: min(100%, var(--board-max-size));
+  aspect-ratio: 1 / 1;
+  display: grid;
+  grid-template-columns: repeat(var(--board-grid-size), 1fr);
+  grid-template-rows: repeat(var(--board-grid-size), 1fr);
+  border-radius: var(--radius-md);
+  border: var(--board-border-width) solid var(--color-border);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.square {
+  position: relative;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: var(--board-piece-size);
+  font-weight: var(--board-piece-weight);
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  line-height: 1;
+  color: var(--color-ink);
+}
+
+.square::before,
+.square::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: var(--board-selection-ring) solid transparent;
+  pointer-events: none;
+}
+
+.square::before {
+  border-width: var(--board-last-move-ring);
+}
+
+.lightSquare {
+  background: var(--board-light-square);
+}
+
+.darkSquare {
+  background: var(--board-dark-square);
+}
+
+.selected::after {
+  border-color: var(--board-selection-color);
+}
+
+.lastMove::before {
+  border-color: var(--board-last-move-color);
+}
+
+.square:focus-visible {
+  outline: var(--board-focus-ring) solid var(--board-focus-color);
+  outline-offset: 0;
+}
+
+.piece {
+  position: relative;
+  z-index: 2;
+  text-transform: uppercase;
+}
+
+.piece[data-color="w"] {
+  color: var(--board-piece-white);
+  text-shadow: 0 1px 2px rgba(43, 31, 22, 0.45);
+}
+
+.piece[data-color="b"] {
+  color: var(--board-piece-black);
+  text-shadow: 0 1px 1px rgba(253, 249, 244, 0.4);
+}
+
+.legalIndicator {
+  position: absolute;
+  width: var(--board-legal-indicator-size);
+  height: var(--board-legal-indicator-size);
+  border-radius: 999px;
+  border: var(--board-legal-indicator-border) solid
+    var(--board-legal-indicator-color);
+  background: transparent;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.statusPanel {
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: var(--font-size-sm);
+}
+
+.statusRow {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  align-items: center;
+}
+
+.statusLabel {
+  color: var(--color-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--font-size-sm);
+}
+
+.statusValue {
+  font-weight: 600;
+}
+
+.fenValue {
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: var(--font-size-sm);
+  text-align: right;
+  word-break: break-all;
+  color: var(--color-ink-muted);
+}
+
+.errorBanner {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--board-error-border);
+  background: var(--board-error-background);
+  color: var(--board-error-text);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 40rem) {
+  .statusRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .fenValue {
+    text-align: left;
+  }
+}

--- a/src/ui/board/Board.tsx
+++ b/src/ui/board/Board.tsx
@@ -1,0 +1,272 @@
+// Interactive chessboard UI wired to ChessState for legal move selection and status display.
+import { useMemo, useState } from "react";
+import type { Color, PieceSymbol, Square } from "chess.js";
+import {
+  ChessState,
+  type BoardPiece,
+  type LegalMove,
+  type PromotionPiece
+} from "../../chess/chessState";
+import { applyMove } from "../../chess/selection";
+import styles from "./Board.module.css";
+
+type BoardSquare = {
+  square: Square;
+  isDark: boolean;
+};
+
+const BOARD_FILES = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+const BOARD_RANKS_DESC = [
+  "8",
+  "7",
+  "6",
+  "5",
+  "4",
+  "3",
+  "2",
+  "1"
+] as const;
+const CHECKERBOARD_MODULO = 2;
+const DARK_SQUARE_PARITY = 1;
+const DEFAULT_PROMOTION: PromotionPiece = "q";
+
+const SIDE_LABELS: Record<Color, string> = {
+  w: "White",
+  b: "Black"
+};
+
+const PIECE_NAMES: Record<PieceSymbol, string> = {
+  p: "Pawn",
+  n: "Knight",
+  b: "Bishop",
+  r: "Rook",
+  q: "Queen",
+  k: "King"
+};
+
+const PIECE_LETTERS: Record<PieceSymbol, string> = {
+  p: "P",
+  n: "N",
+  b: "B",
+  r: "R",
+  q: "Q",
+  k: "K"
+};
+
+const BOARD_SQUARES: BoardSquare[] = BOARD_RANKS_DESC.flatMap(
+  (rank, rankIndex) =>
+    BOARD_FILES.map((file, fileIndex) => {
+      const square = `${file}${rank}` as Square;
+      const isDark =
+        (fileIndex + rankIndex) % CHECKERBOARD_MODULO === DARK_SQUARE_PARITY;
+
+      return {
+        square,
+        isDark
+      };
+    })
+);
+
+const MOVE_ERROR_MESSAGE = "That move is not legal for the current position.";
+
+type BoardProps = {
+  initialFen?: string;
+};
+
+export function Board({ initialFen }: BoardProps) {
+  const [chessState] = useState(() => new ChessState(initialFen));
+  const [fen, setFen] = useState(() => chessState.getFen());
+  const [sideToMove, setSideToMove] = useState(() => chessState.getSideToMove());
+  const [isCheck, setIsCheck] = useState(() => chessState.isInCheck());
+  const [selectedSquare, setSelectedSquare] = useState<Square | null>(null);
+  const [legalMoves, setLegalMoves] = useState<LegalMove[]>([]);
+  const [lastMove, setLastMove] = useState<{
+    from: Square;
+    to: Square;
+  } | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const legalDestinations = useMemo(
+    () => new Set(legalMoves.map((move) => move.to)),
+    [legalMoves]
+  );
+
+  const refreshStatus = () => {
+    setFen(chessState.getFen());
+    setSideToMove(chessState.getSideToMove());
+    setIsCheck(chessState.isInCheck());
+  };
+
+  const clearSelection = () => {
+    setSelectedSquare(null);
+    setLegalMoves([]);
+  };
+
+  const selectSquare = (square: Square) => {
+    setSelectedSquare(square);
+    setLegalMoves(chessState.legalMovesForSquare(square));
+  };
+
+  const applySelectedMove = (destination: Square) => {
+    if (!selectedSquare) {
+      return;
+    }
+
+    const candidateMoves = legalMoves.filter((move) => move.to === destination);
+    const promotion = pickPromotion(candidateMoves);
+    const result = applyMove(chessState, {
+      from: selectedSquare,
+      to: destination,
+      promotion
+    });
+
+    if (!result.ok) {
+      setErrorMessage(MOVE_ERROR_MESSAGE);
+      return;
+    }
+
+    setLastMove({ from: result.move.from, to: result.move.to });
+    refreshStatus();
+    clearSelection();
+    setErrorMessage(null);
+  };
+
+  const handleSquareClick = (square: Square) => {
+    if (selectedSquare) {
+      if (square === selectedSquare) {
+        clearSelection();
+        return;
+      }
+
+      if (legalDestinations.has(square)) {
+        applySelectedMove(square);
+        return;
+      }
+    }
+
+    const piece = chessState.getPiece(square);
+
+    if (piece && piece.color === sideToMove) {
+      selectSquare(square);
+      setErrorMessage(null);
+      return;
+    }
+
+    clearSelection();
+  };
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.boardWrapper}>
+        <div className={styles.board} role="grid" aria-label="Chess board">
+          {BOARD_SQUARES.map((squareData) => {
+            const piece = chessState.getPiece(squareData.square);
+            const isSelected = selectedSquare === squareData.square;
+            const isLegalDestination = legalDestinations.has(squareData.square);
+            const isLastMove =
+              lastMove?.from === squareData.square ||
+              lastMove?.to === squareData.square;
+            const className = [
+              styles.square,
+              squareData.isDark ? styles.darkSquare : styles.lightSquare,
+              isSelected ? styles.selected : "",
+              isLastMove ? styles.lastMove : ""
+            ]
+              .filter(Boolean)
+              .join(" ");
+
+            return (
+              <button
+                key={squareData.square}
+                type="button"
+                className={className}
+                onClick={() => handleSquareClick(squareData.square)}
+                aria-pressed={isSelected}
+                aria-label={buildSquareLabel(squareData.square, piece)}
+                data-square={squareData.square}
+                data-testid={`square-${squareData.square}`}
+                data-legal-destination={
+                  isLegalDestination ? "true" : undefined
+                }
+                data-last-move={isLastMove ? "true" : undefined}
+              >
+                {piece ? (
+                  <span
+                    className={styles.piece}
+                    data-color={piece.color}
+                    aria-hidden="true"
+                  >
+                    {renderPieceLetter(piece)}
+                  </span>
+                ) : null}
+                {isLegalDestination ? (
+                  <span className={styles.legalIndicator} aria-hidden="true" />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={styles.statusPanel} aria-live="polite">
+        <div className={styles.statusRow}>
+          <span className={styles.statusLabel}>Side to move</span>
+          <span className={styles.statusValue} data-testid="side-to-move">
+            {SIDE_LABELS[sideToMove]}
+          </span>
+        </div>
+        <div className={styles.statusRow}>
+          <span className={styles.statusLabel}>Check</span>
+          <span className={styles.statusValue} data-testid="check-status">
+            {isCheck ? "Yes" : "No"}
+          </span>
+        </div>
+        <div className={styles.statusRow}>
+          <span className={styles.statusLabel}>FEN</span>
+          <span className={styles.fenValue} data-testid="fen-value">
+            {fen}
+          </span>
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <p className={styles.errorBanner} role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function pickPromotion(moves: LegalMove[]): PromotionPiece | undefined {
+  const promotionMoves = moves.filter(
+    (move) => move.isPromotion && move.promotion
+  );
+
+  if (promotionMoves.length === 0) {
+    return undefined;
+  }
+
+  // Default to queen until a promotion picker is implemented.
+  const preferred = promotionMoves.find(
+    (move) => move.promotion === DEFAULT_PROMOTION
+  );
+
+  return (preferred ?? promotionMoves[0]).promotion;
+}
+
+function renderPieceLetter(piece: BoardPiece): string {
+  const base = PIECE_LETTERS[piece.type];
+  return piece.color === "w" ? base : base.toLowerCase();
+}
+
+function buildSquareLabel(square: Square, piece: BoardPiece | null): string {
+  if (!piece) {
+    return `Square ${square}`;
+  }
+
+  const colorLabel = SIDE_LABELS[piece.color];
+  const pieceLabel = PIECE_NAMES[piece.type];
+
+  return `Square ${square}, ${colorLabel} ${pieceLabel}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts']
+    environment: "jsdom",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: ["src/test/setup.ts"],
+    css: true
   }
 });


### PR DESCRIPTION
Implements a clickable chessboard with selection, legal move highlights, and last-move styling wired to ChessState.

Adds board integration tests and updates vitest setup to run React tests reliably for issue #4.
