### PR TITLE
feat: add move history navigation (#6)

### DIFF
--- a/src/ui/app-shell/AppShell.module.css
+++ b/src/ui/app-shell/AppShell.module.css
@@ -112,14 +112,6 @@
   gap: var(--space-lg);
 }
 
-.mainMeta {
-  padding: var(--space-md);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-ink-muted);
-  font-size: var(--font-size-sm);
-}
-
 .sidebar {
   background: var(--color-surface-strong);
   border-radius: var(--radius-lg);

--- a/src/ui/app-shell/AppShell.tsx
+++ b/src/ui/app-shell/AppShell.tsx
@@ -19,9 +19,6 @@ export function AppShell() {
       <main className={styles.main}>
         <section className={styles.boardCard} aria-label="Board area">
           <Board />
-          <div className={styles.mainMeta}>
-            Move list, clocks, and controls will live in this space.
-          </div>
         </section>
       </main>
 

--- a/src/ui/board/Board.integration.test.tsx
+++ b/src/ui/board/Board.integration.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Board } from "./Board";
 
@@ -7,16 +7,34 @@ const START_FEN =
 const EXPECTED_KNIGHT_DESTINATIONS = ["a3", "c3"];
 const EXPECTED_FEN_AFTER_E4 =
   "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+const EXPECTED_FEN_AFTER_E5 =
+  "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2";
 const EXPECTED_SIDE_AFTER_E4 = "Black";
+const EXPECTED_SIDE_AT_START = "White";
+const EXPECTED_SIDE_AFTER_E5 = "White";
+const EXPECTED_MOVE_E4 = "e4";
+const EXPECTED_MOVE_E5 = "e5";
+const MOVE_HISTORY_TEST_ID = "move-history";
+const NAV_START_TEST_ID = "nav-start";
+const NAV_BACK_TEST_ID = "nav-back";
+const NAV_FORWARD_TEST_ID = "nav-forward";
+const NAV_END_TEST_ID = "nav-end";
+const WHITE_OPENING_FROM = "e2";
+const WHITE_OPENING_TO = "e4";
+const BLACK_OPENING_FROM = "e7";
+const BLACK_OPENING_TO = "e5";
 
 const getLegalDestinations = (board: HTMLElement): string[] =>
-  Array.from(
-    board.querySelectorAll('[data-legal-destination="true"]')
-  )
+  Array.from(board.querySelectorAll('[data-legal-destination="true"]'))
     .map((element) => element.getAttribute("data-square"))
     .filter((square): square is string => Boolean(square));
 
 const sortSquares = (squares: string[]): string[] => [...squares].sort();
+
+const makeMove = (from: string, to: string) => {
+  fireEvent.click(screen.getByTestId(`square-${from}`));
+  fireEvent.click(screen.getByTestId(`square-${to}`));
+};
 
 describe("Board integration", () => {
   it("shows the legal destinations for a selected piece", () => {
@@ -38,14 +56,63 @@ describe("Board integration", () => {
   it("updates FEN and side to move after a move", () => {
     render(<Board initialFen={START_FEN} />);
 
-    fireEvent.click(screen.getByTestId("square-e2"));
-    fireEvent.click(screen.getByTestId("square-e4"));
+    makeMove(WHITE_OPENING_FROM, WHITE_OPENING_TO);
 
     expect(screen.getByTestId("fen-value").textContent).toBe(
       EXPECTED_FEN_AFTER_E4
     );
     expect(screen.getByTestId("side-to-move").textContent).toBe(
       EXPECTED_SIDE_AFTER_E4
+    );
+  });
+
+  it("adds moves to the history list", () => {
+    render(<Board initialFen={START_FEN} />);
+
+    makeMove(WHITE_OPENING_FROM, WHITE_OPENING_TO);
+    makeMove(BLACK_OPENING_FROM, BLACK_OPENING_TO);
+
+    const history = screen.getByTestId(MOVE_HISTORY_TEST_ID);
+
+    expect(within(history).getByText(EXPECTED_MOVE_E4)).toBeInTheDocument();
+    expect(within(history).getByText(EXPECTED_MOVE_E5)).toBeInTheDocument();
+  });
+
+  it("navigates through history and updates the board position", () => {
+    render(<Board initialFen={START_FEN} />);
+
+    makeMove(WHITE_OPENING_FROM, WHITE_OPENING_TO);
+    makeMove(BLACK_OPENING_FROM, BLACK_OPENING_TO);
+
+    fireEvent.click(screen.getByTestId(NAV_START_TEST_ID));
+
+    expect(screen.getByTestId("fen-value").textContent).toBe(START_FEN);
+    expect(screen.getByTestId("side-to-move").textContent).toBe(
+      EXPECTED_SIDE_AT_START
+    );
+
+    fireEvent.click(screen.getByTestId(NAV_FORWARD_TEST_ID));
+
+    expect(screen.getByTestId("fen-value").textContent).toBe(
+      EXPECTED_FEN_AFTER_E4
+    );
+    expect(screen.getByTestId("side-to-move").textContent).toBe(
+      EXPECTED_SIDE_AFTER_E4
+    );
+
+    fireEvent.click(screen.getByTestId(NAV_END_TEST_ID));
+
+    expect(screen.getByTestId("fen-value").textContent).toBe(
+      EXPECTED_FEN_AFTER_E5
+    );
+    expect(screen.getByTestId("side-to-move").textContent).toBe(
+      EXPECTED_SIDE_AFTER_E5
+    );
+
+    fireEvent.click(screen.getByTestId(NAV_BACK_TEST_ID));
+
+    expect(screen.getByTestId("fen-value").textContent).toBe(
+      EXPECTED_FEN_AFTER_E4
     );
   });
 });

--- a/src/ui/board/Board.module.css
+++ b/src/ui/board/Board.module.css
@@ -18,9 +18,26 @@
   --board-legal-indicator-color: rgba(31, 26, 23, 0.35);
   --board-focus-ring: 3px;
   --board-focus-color: rgba(31, 26, 23, 0.5);
+  --board-disabled-opacity: 1;
   --board-error-border: #d5a6a6;
   --board-error-background: #f6e8e8;
   --board-error-text: #5b1d1d;
+
+  --history-panel-background: var(--color-surface);
+  --history-panel-border: var(--color-border);
+  --history-panel-title: var(--color-ink);
+  --history-panel-meta: var(--color-ink-muted);
+  --history-number-width: 2.75rem;
+  --history-move-padding-block: var(--space-2xs);
+  --history-move-padding-inline: var(--space-sm);
+  --history-move-hover: rgba(160, 91, 46, 0.12);
+  --history-move-current: rgba(160, 91, 46, 0.22);
+  --history-move-border: rgba(160, 91, 46, 0.28);
+  --history-nav-background: var(--color-surface-strong);
+  --history-nav-disabled: rgba(31, 26, 23, 0.4);
+  --history-button-weight: 600;
+  --history-focus-offset: 1px;
+  --history-transition-duration: 150ms;
 }
 
 .panel {
@@ -58,6 +75,11 @@
   font-family: "Space Grotesk", "Segoe UI", sans-serif;
   line-height: 1;
   color: var(--color-ink);
+}
+
+.square:disabled {
+  cursor: not-allowed;
+  opacity: var(--board-disabled-opacity);
 }
 
 .square::before,
@@ -168,6 +190,117 @@
   font-size: var(--font-size-sm);
 }
 
+.historyPanel {
+  display: grid;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--history-panel-border);
+  background: var(--history-panel-background);
+}
+
+.historyHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.historyTitle {
+  margin: 0;
+  font-size: var(--font-size-base);
+  color: var(--history-panel-title);
+}
+
+.historyStatus {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--history-panel-meta);
+}
+
+.historyNav {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.navButton {
+  border: 1px solid var(--color-border);
+  background: var(--history-nav-background);
+  color: var(--color-ink);
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--history-button-weight);
+  cursor: pointer;
+}
+
+.navButton:disabled {
+  cursor: not-allowed;
+  color: var(--history-nav-disabled);
+  background: var(--color-panel);
+}
+
+.historyList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.historyRow {
+  display: grid;
+  grid-template-columns: var(--history-number-width) 1fr 1fr;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.moveNumber {
+  font-size: var(--font-size-sm);
+  color: var(--history-panel-meta);
+}
+
+.moveButton {
+  border: 1px solid transparent;
+  background: transparent;
+  padding: var(--history-move-padding-block) var(--history-move-padding-inline);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--history-transition-duration) ease,
+    border-color var(--history-transition-duration) ease;
+}
+
+.moveButton:hover {
+  background: var(--history-move-hover);
+}
+
+.moveButton:focus-visible {
+  outline: var(--board-focus-ring) solid var(--board-focus-color);
+  outline-offset: var(--history-focus-offset);
+}
+
+.currentMove {
+  background: var(--history-move-current);
+  border-color: var(--history-move-border);
+  font-weight: var(--history-button-weight);
+}
+
+.pendingMove {
+  font-size: var(--font-size-sm);
+  color: var(--history-panel-meta);
+  padding: var(--history-move-padding-block) var(--history-move-padding-inline);
+}
+
+.historyEmpty {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--history-panel-meta);
+}
+
 @media (max-width: 40rem) {
   .statusRow {
     flex-direction: column;
@@ -176,5 +309,9 @@
 
   .fenValue {
     text-align: left;
+  }
+
+  .historyHeader {
+    align-items: flex-start;
   }
 }

--- a/src/ui/board/Board.tsx
+++ b/src/ui/board/Board.tsx
@@ -4,6 +4,7 @@ import type { Color, PieceSymbol, Square } from 'chess.js';
 import {
   ChessState,
   type LegalMove as StateLegalMove,
+  type MoveRecord,
   type PromotionPiece
 } from '../../chess/chessState';
 import { applyMove } from '../../chess/selection';
@@ -29,11 +30,28 @@ type BoardSquare = {
   isDark: boolean;
 };
 
+type MoveRow = {
+  moveNumber: number;
+  whiteMove: MoveRecord;
+  blackMove?: MoveRecord;
+  whitePly: number;
+  blackPly?: number;
+};
+
 const BOARD_FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 const BOARD_RANKS_DESC = ['8', '7', '6', '5', '4', '3', '2', '1'] as const;
 const CHECKERBOARD_MODULO = 2;
 const DARK_SQUARE_PARITY = 1;
 const DEFAULT_PROMOTION: PromotionPiece = 'q';
+
+const START_PLY_INDEX = 0;
+const START_HISTORY_INDEX = 0;
+const SINGLE_PLY = 1;
+const PLIES_PER_FULL_MOVE = 2;
+const FIRST_FULL_MOVE_NUMBER = 1;
+const FIRST_PLY_NUMBER = 1;
+const WHITE_PLY_OFFSET = 0;
+const BLACK_PLY_OFFSET = 1;
 
 const SIDE_LABELS: Record<Color, string> = {
   w: 'White',
@@ -73,19 +91,51 @@ const BOARD_SQUARES: BoardSquare[] = BOARD_RANKS_DESC.flatMap(
 );
 
 const MOVE_ERROR_MESSAGE = 'That move is not legal for the current position.';
+const HISTORY_TITLE = 'Move History';
+const HISTORY_EMPTY_MESSAGE = 'No moves yet.';
+const HISTORY_STATUS_LATEST = 'Latest position.';
+const HISTORY_STATUS_START =
+  'Viewing start position. Return to latest to make moves.';
+const HISTORY_STATUS_VIEWING_PREFIX = 'Viewing move';
+const HISTORY_STATUS_VIEWING_INFIX = 'of';
+const HISTORY_STATUS_VIEWING_SUFFIX = 'Return to latest to make moves.';
+const NAV_START_LABEL = 'Start';
+const NAV_BACK_LABEL = 'Back';
+const NAV_FORWARD_LABEL = 'Forward';
+const NAV_END_LABEL = 'End';
+const MOVE_NAVIGATION_LABEL = 'Move navigation';
+const MOVE_HISTORY_LABEL = 'Move history';
+const PENDING_MOVE_LABEL = '--';
+const MOVE_BUTTON_TEST_ID_PREFIX = 'move';
 
 export function Board(props: BoardProps) {
   const isControlled = 'pieces' in props;
   const initialFen = !isControlled ? props.initialFen : undefined;
 
   const [chessState] = useState(() => new ChessState(initialFen));
-  const [fen, setFen] = useState(() => chessState.getFen());
-  const [sideToMove, setSideToMove] = useState(() => chessState.getSideToMove());
-  const [isCheck, setIsCheck] = useState(() => chessState.isInCheck());
-  const [internalSelectedSquare, setInternalSelectedSquare] = useState<Square | null>(null);
+  const [startFen] = useState(() => chessState.getFen());
+  const [currentPly, setCurrentPly] = useState(() => START_PLY_INDEX);
+  const [internalSelectedSquare, setInternalSelectedSquare] =
+    useState<Square | null>(null);
   const [legalMoves, setLegalMoves] = useState<StateLegalMove[]>([]);
-  const [internalLastMove, setInternalLastMove] = useState<{ from: Square; to: Square } | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const history = chessState.getHistory();
+  const latestPly = history.length;
+  const isViewingLatest = currentPly === latestPly;
+
+  const viewFen =
+    currentPly === START_PLY_INDEX
+      ? startFen
+      : history[currentPly - SINGLE_PLY]?.after ?? startFen;
+  const viewState = useMemo(() => new ChessState(viewFen), [viewFen]);
+  const sideToMove = viewState.getSideToMove();
+  const isCheck = viewState.isInCheck();
+  const fen = viewState.getFen();
+  const lastMove =
+    currentPly === START_PLY_INDEX
+      ? null
+      : history[currentPly - SINGLE_PLY] ?? null;
 
   const internalLegalDestinations = useMemo(
     () => new Set(legalMoves.map((move) => move.to)),
@@ -98,13 +148,7 @@ export function Board(props: BoardProps) {
   const selectedSquare = isControlled
     ? props.selectedSquare
     : internalSelectedSquare;
-  const lastMove = isControlled ? props.lastMove : internalLastMove ?? undefined;
-
-  const refreshStatus = () => {
-    setFen(chessState.getFen());
-    setSideToMove(chessState.getSideToMove());
-    setIsCheck(chessState.isInCheck());
-  };
+  const lastMoveHighlight = isControlled ? props.lastMove : lastMove ?? undefined;
 
   const clearSelection = () => {
     setInternalSelectedSquare(null);
@@ -114,6 +158,16 @@ export function Board(props: BoardProps) {
   const selectSquare = (square: Square) => {
     setInternalSelectedSquare(square);
     setLegalMoves(chessState.legalMovesForSquare(square));
+  };
+
+  const goToPly = (targetPly: number) => {
+    const clampedPly = Math.min(
+      Math.max(targetPly, START_PLY_INDEX),
+      latestPly
+    );
+    setCurrentPly(clampedPly);
+    clearSelection();
+    setErrorMessage(null);
   };
 
   const applySelectedMove = (destination: Square) => {
@@ -134,13 +188,16 @@ export function Board(props: BoardProps) {
       return;
     }
 
-    setInternalLastMove({ from: result.move.from, to: result.move.to });
-    refreshStatus();
+    setCurrentPly(chessState.getHistory().length);
     clearSelection();
     setErrorMessage(null);
   };
 
-  const handleInternalSquareClick = (square: Square) => {
+  const handleUncontrolledSquareClick = (square: Square) => {
+    if (!isViewingLatest) {
+      return;
+    }
+
     if (internalSelectedSquare) {
       if (square === internalSelectedSquare) {
         clearSelection();
@@ -153,7 +210,7 @@ export function Board(props: BoardProps) {
       }
     }
 
-    const piece = chessState.getPiece(square);
+    const piece = viewState.getPiece(square);
 
     if (piece && piece.color === sideToMove) {
       selectSquare(square);
@@ -170,19 +227,21 @@ export function Board(props: BoardProps) {
       return;
     }
 
-    handleInternalSquareClick(square);
+    handleUncontrolledSquareClick(square);
   };
 
-  const renderBoard = () => (
+  const renderBoard = (
+    pieceAt: (square: Square) => BoardPiece | null,
+    isDisabled: boolean
+  ) => (
     <div className={styles.board} role="grid" aria-label="Chess board">
       {BOARD_SQUARES.map((squareData) => {
-        const piece = isControlled
-          ? props.pieces[squareData.square]
-          : chessState.getPiece(squareData.square);
+        const piece = pieceAt(squareData.square);
         const isSelected = selectedSquare === squareData.square;
         const isLegalDestination = legalDestinations.has(squareData.square);
         const isLastMove =
-          lastMove?.from === squareData.square || lastMove?.to === squareData.square;
+          lastMoveHighlight?.from === squareData.square ||
+          lastMoveHighlight?.to === squareData.square;
 
         const className = [
           styles.square,
@@ -205,6 +264,7 @@ export function Board(props: BoardProps) {
             data-testid={`square-${squareData.square}`}
             data-legal-destination={isLegalDestination ? 'true' : undefined}
             data-last-move={isLastMove ? 'true' : undefined}
+            disabled={isDisabled}
           >
             {piece ? (
               <span
@@ -225,12 +285,19 @@ export function Board(props: BoardProps) {
   );
 
   if (isControlled) {
-    return renderBoard();
+    return renderBoard((square) => props.pieces[square], false);
   }
+
+  const moveRows = buildMoveRows(history);
+  const historyStatus = buildHistoryStatus(currentPly, latestPly);
+  const canNavigateBack = currentPly > START_PLY_INDEX;
+  const canNavigateForward = currentPly < latestPly;
 
   return (
     <div className={styles.panel}>
-      <div className={styles.boardWrapper}>{renderBoard()}</div>
+      <div className={styles.boardWrapper}>
+        {renderBoard((square) => viewState.getPiece(square), !isViewingLatest)}
+      </div>
 
       <div className={styles.statusPanel} aria-live="polite">
         <div className={styles.statusRow}>
@@ -258,11 +325,154 @@ export function Board(props: BoardProps) {
           {errorMessage}
         </p>
       ) : null}
+
+      <section className={styles.historyPanel} aria-label={MOVE_HISTORY_LABEL}>
+        <div className={styles.historyHeader}>
+          <div>
+            <h3 className={styles.historyTitle}>{HISTORY_TITLE}</h3>
+            <p className={styles.historyStatus} data-testid="history-status">
+              {historyStatus}
+            </p>
+          </div>
+          <div className={styles.historyNav} role="group" aria-label={MOVE_NAVIGATION_LABEL}>
+            <button
+              type="button"
+              className={styles.navButton}
+              onClick={() => goToPly(START_PLY_INDEX)}
+              disabled={!canNavigateBack}
+              data-testid="nav-start"
+            >
+              {NAV_START_LABEL}
+            </button>
+            <button
+              type="button"
+              className={styles.navButton}
+              onClick={() => goToPly(currentPly - SINGLE_PLY)}
+              disabled={!canNavigateBack}
+              data-testid="nav-back"
+            >
+              {NAV_BACK_LABEL}
+            </button>
+            <button
+              type="button"
+              className={styles.navButton}
+              onClick={() => goToPly(currentPly + SINGLE_PLY)}
+              disabled={!canNavigateForward}
+              data-testid="nav-forward"
+            >
+              {NAV_FORWARD_LABEL}
+            </button>
+            <button
+              type="button"
+              className={styles.navButton}
+              onClick={() => goToPly(latestPly)}
+              disabled={!canNavigateForward}
+              data-testid="nav-end"
+            >
+              {NAV_END_LABEL}
+            </button>
+          </div>
+        </div>
+
+        {moveRows.length === START_PLY_INDEX ? (
+          <p className={styles.historyEmpty}>{HISTORY_EMPTY_MESSAGE}</p>
+        ) : (
+          <ol className={styles.historyList} data-testid="move-history">
+            {moveRows.map((row) => {
+              const isWhiteCurrent = currentPly === row.whitePly;
+              const isBlackCurrent = currentPly === row.blackPly;
+              const whiteClassName = [
+                styles.moveButton,
+                isWhiteCurrent ? styles.currentMove : ''
+              ]
+                .filter(Boolean)
+                .join(' ');
+              const blackClassName = [
+                styles.moveButton,
+                isBlackCurrent ? styles.currentMove : ''
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              return (
+                <li key={row.moveNumber} className={styles.historyRow}>
+                  <span className={styles.moveNumber}>{row.moveNumber}.</span>
+                  <button
+                    type="button"
+                    className={whiteClassName}
+                    onClick={() => goToPly(row.whitePly)}
+                    data-testid={`${MOVE_BUTTON_TEST_ID_PREFIX}-${row.whitePly}`}
+                    aria-current={isWhiteCurrent ? 'true' : undefined}
+                  >
+                    {row.whiteMove.san}
+                  </button>
+                  {row.blackMove && row.blackPly ? (
+                    <button
+                      type="button"
+                      className={blackClassName}
+                      onClick={() => goToPly(row.blackPly)}
+                      data-testid={`${MOVE_BUTTON_TEST_ID_PREFIX}-${row.blackPly}`}
+                      aria-current={isBlackCurrent ? 'true' : undefined}
+                    >
+                      {row.blackMove.san}
+                    </button>
+                  ) : (
+                    <span className={styles.pendingMove}>{PENDING_MOVE_LABEL}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
     </div>
   );
 }
 
 export default Board;
+
+function buildMoveRows(history: MoveRecord[]): MoveRow[] {
+  const rows: MoveRow[] = [];
+
+  for (
+    let index = START_HISTORY_INDEX;
+    index < history.length;
+    index += PLIES_PER_FULL_MOVE
+  ) {
+    const whiteMove = history[index + WHITE_PLY_OFFSET];
+
+    if (!whiteMove) {
+      continue;
+    }
+
+    const blackMove = history[index + BLACK_PLY_OFFSET];
+    const moveNumber = index / PLIES_PER_FULL_MOVE + FIRST_FULL_MOVE_NUMBER;
+    const whitePly = index + FIRST_PLY_NUMBER;
+    const blackPly = blackMove ? index + PLIES_PER_FULL_MOVE : undefined;
+
+    rows.push({
+      moveNumber,
+      whiteMove,
+      blackMove,
+      whitePly,
+      blackPly
+    });
+  }
+
+  return rows;
+}
+
+function buildHistoryStatus(currentPly: number, latestPly: number): string {
+  if (currentPly === latestPly) {
+    return HISTORY_STATUS_LATEST;
+  }
+
+  if (currentPly === START_PLY_INDEX) {
+    return HISTORY_STATUS_START;
+  }
+
+  return `${HISTORY_STATUS_VIEWING_PREFIX} ${currentPly} ${HISTORY_STATUS_VIEWING_INFIX} ${latestPly}. ${HISTORY_STATUS_VIEWING_SUFFIX}`;
+}
 
 function pickPromotion(moves: StateLegalMove[]): PromotionPiece | undefined {
   const promotionMoves = moves.filter(


### PR DESCRIPTION
Adds a SAN move list with navigation controls and history-aware board rendering.

Prevents moves while reviewing past plies to keep state consistent.
