### PR TITLE
feat: add analysis request id for e2e (#10)

### DIFF
--- a/src/engine/useEngineAnalysis.ts
+++ b/src/engine/useEngineAnalysis.ts
@@ -132,6 +132,7 @@ function useEngineAnalysis({ fen, enabled, settings }: UseEngineAnalysisArgs) {
 
   return {
     lines: state.lines,
+    requestId: state.requestId,
     status: state.status,
     error: state.error,
     restart

--- a/src/ui/ChessApp.tsx
+++ b/src/ui/ChessApp.tsx
@@ -262,6 +262,7 @@ function ChessApp({ initialFen = DEFAULT_STARTING_FEN }: ChessAppProps) {
               lines={analysis.lines}
               status={analysis.status}
               error={analysis.error}
+              requestId={analysis.requestId}
               onToggle={setAnalysisEnabled}
               onModeChange={setAnalysisMode}
               onValueChange={handleAnalysisValueChange}

--- a/src/ui/panels/AnalysisPanel.tsx
+++ b/src/ui/panels/AnalysisPanel.tsx
@@ -4,6 +4,7 @@ import styles from './AnalysisPanel.module.css';
 const CENTIPAWN_SCALE = 100; // Convert centipawns to pawn units.
 const PAWN_DECIMALS = 2; // Show two decimals for evaluation.
 const MIN_ANALYSIS_VALUE = 1; // Analysis settings must be positive.
+const REQUEST_ID_IDLE = 'idle'; // Placeholder when analysis is not running.
 
 const ANALYSIS_MODES: Array<{ value: AnalysisMode; label: string }> = [
   { value: 'depth', label: 'Depth' },
@@ -18,6 +19,7 @@ type AnalysisPanelProps = {
   lines: AnalysisLine[];
   status: 'idle' | 'running' | 'error';
   error?: string;
+  requestId: string | null;
   onToggle: (enabled: boolean) => void;
   onModeChange: (mode: AnalysisMode) => void;
   onValueChange: (value: number) => void;
@@ -40,13 +42,18 @@ function AnalysisPanel({
   lines,
   status,
   error,
+  requestId,
   onToggle,
   onModeChange,
   onValueChange,
   onRestart
 }: AnalysisPanelProps) {
   return (
-    <div className={styles.panel}>
+    <div
+      className={styles.panel}
+      data-testid="analysis-panel"
+      data-request-id={requestId ?? REQUEST_ID_IDLE}
+    >
       <div className={styles.controls}>
         <button
           type="button"

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 const MOVE_LIST_TEST_ID = 'move-list';
+const SIDE_TO_MOVE_TEST_ID = 'side-to-move';
+const ANALYSIS_PANEL_TEST_ID = 'analysis-panel';
 const ANALYSIS_LINE_1 = 'analysis-line-1';
 const ANALYSIS_LINE_2 = 'analysis-line-2';
 const ANALYSIS_LINE_3 = 'analysis-line-3';
@@ -12,9 +14,12 @@ const MOVE_END = 'square-e4';
 
 const ANALYSIS_POLL_TIMEOUT = 20_000;
 const FAST_ANALYSIS_VALUE = '4';
+const REQUEST_ID_IDLE = 'idle';
 
 test('smoke: move shows in history and analysis refreshes', async ({ page }) => {
   await page.goto('/');
+
+  await expect(page.getByTestId(SIDE_TO_MOVE_TEST_ID)).toBeVisible();
 
   await page.getByTestId(MOVE_START).click();
   await page.getByTestId(MOVE_END).click();
@@ -24,16 +29,23 @@ test('smoke: move shows in history and analysis refreshes', async ({ page }) => 
   await page.getByTestId(ANALYSIS_VALUE_INPUT).fill(FAST_ANALYSIS_VALUE);
   await page.getByTestId(ANALYSIS_TOGGLE).click();
 
+  const analysisPanel = page.getByTestId(ANALYSIS_PANEL_TEST_ID);
+  const getRequestId = async () => (await analysisPanel.getAttribute('data-request-id')) ?? '';
+
+  await expect.poll(getRequestId, { timeout: ANALYSIS_POLL_TIMEOUT }).not.toBe(REQUEST_ID_IDLE);
+
   await expect(page.getByTestId(ANALYSIS_LINE_1)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
   await expect(page.getByTestId(ANALYSIS_LINE_2)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
   await expect(page.getByTestId(ANALYSIS_LINE_3)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
 
-  const lineBefore = await page.getByTestId(ANALYSIS_LINE_1).textContent();
+  const requestIdBefore = await getRequestId();
 
   await page.getByTestId('square-e7').click();
   await page.getByTestId('square-e5').click();
 
-  await expect.poll(async () => page.getByTestId(ANALYSIS_LINE_1).textContent(), {
-    timeout: ANALYSIS_POLL_TIMEOUT
-  }).not.toBe(lineBefore);
+  await expect.poll(getRequestId, { timeout: ANALYSIS_POLL_TIMEOUT }).not.toBe(requestIdBefore);
+
+  await expect(page.getByTestId(ANALYSIS_LINE_1)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
+  await expect(page.getByTestId(ANALYSIS_LINE_2)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
+  await expect(page.getByTestId(ANALYSIS_LINE_3)).toBeVisible({ timeout: ANALYSIS_POLL_TIMEOUT });
 });


### PR DESCRIPTION
Expose analysis request ids on the analysis panel for stable Playwright assertions.

Update the smoke test to validate analysis refreshes after moves.
