### PR TITLE
fix: guard stockfish worker url resolution (#30)

### DIFF
--- a/src/engine/stockfishWorkerUrlCheck.test.ts
+++ b/src/engine/stockfishWorkerUrlCheck.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STOCKFISH_WORKER_URL_IMPORT,
+  ensureStockfishWorkerUrlResolved
+} from './stockfishWorkerUrlCheck';
+
+const RESOLVED_ID = '/assets/stockfish-worker.js';
+
+describe('ensureStockfishWorkerUrlResolved', () => {
+  it('uses the Stockfish worker URL import specifier', async () => {
+    let receivedId = '';
+    const resolveId = async (id: string) => {
+      receivedId = id;
+      return { id: RESOLVED_ID };
+    };
+
+    await ensureStockfishWorkerUrlResolved(resolveId);
+
+    expect(receivedId).toBe(STOCKFISH_WORKER_URL_IMPORT);
+  });
+
+  it('throws when the worker URL cannot be resolved', async () => {
+    const resolveId = async () => null;
+
+    await expect(ensureStockfishWorkerUrlResolved(resolveId)).rejects.toThrow(
+      /Stockfish worker URL could not be resolved/
+    );
+  });
+});

--- a/src/engine/stockfishWorkerUrlCheck.ts
+++ b/src/engine/stockfishWorkerUrlCheck.ts
@@ -1,0 +1,20 @@
+// Validates that Vite can resolve the Stockfish worker asset URL import.
+// Keep this import specifier in sync with the Stockfish worker import.
+export const STOCKFISH_WORKER_URL_IMPORT =
+  'stockfish/src/stockfish-17.1-lite-single-03e3232.js?url';
+
+const STOCKFISH_WORKER_URL_ERROR =
+  `Stockfish worker URL could not be resolved for ${STOCKFISH_WORKER_URL_IMPORT}. ` +
+  'Verify the stockfish dependency and update src/engine/stockfishWorker.ts if needed.';
+
+export type ResolveId = (id: string) => Promise<{ id: string } | null>;
+
+export async function ensureStockfishWorkerUrlResolved(
+  resolveId: ResolveId
+): Promise<void> {
+  const resolved = await resolveId(STOCKFISH_WORKER_URL_IMPORT);
+
+  if (!resolved || !resolved.id) {
+    throw new Error(STOCKFISH_WORKER_URL_ERROR);
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,21 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { ensureStockfishWorkerUrlResolved } from './src/engine/stockfishWorkerUrlCheck';
 
 const DEV_SERVER_PORT = 5173; // Vite default.
 
+function stockfishWorkerUrlCheck(): Plugin {
+  return {
+    name: 'stockfish-worker-url-check',
+    enforce: 'pre',
+    async buildStart() {
+      await ensureStockfishWorkerUrlResolved((id) => this.resolve(id));
+    }
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [stockfishWorkerUrlCheck(), react()],
   server: {
     port: DEV_SERVER_PORT
   }


### PR DESCRIPTION
Adds a Vite startup check that resolves the Stockfish worker asset import.

Fails fast in dev/build when the engine worker URL cannot be resolved.
